### PR TITLE
Escape Status#message when render in views (fix XSS)

### DIFF
--- a/lib/resque/server/views/status.erb
+++ b/lib/resque/server/views/status.erb
@@ -9,7 +9,7 @@
     <div class="status-progress-bar status-<%= @status.status %>" style="width: <%= @status.pct_complete %>%;"></div>
     <p><%= @status.pct_complete %>%</p>
   </div>
-  <div class="status-message"><%= @status.message %></div>
+  <div class="status-message"><%=h @status.message %></div>
   <div class="status-time"><%= @status.time? ? @status.time : 'Not started' %></div>
 
   <h2>Details</h2>

--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -36,7 +36,7 @@
         <div class="progress-bar" style="width:<%= status.pct_complete %>%">&nbsp;</div>
         <div class="progress-pct"><%= status.pct_complete ? "#{status.pct_complete}%" : '' %></div>
       </td>
-      <td><%= status.message %></td>
+      <td><%=h status.message %></td>
       <td><% if status.killable? %><a href="<%= u(:statuses) %>/<%= status.uuid %>/kill" class="kill">Kill</a><% end %></td>
     </tr>
     <% end %>


### PR DESCRIPTION
Fix XSS possibility and HTML rendering which is stored in Status message

Before:
<img width="844" alt="1" src="https://user-images.githubusercontent.com/8654229/148529308-1dd237cf-d83e-4da1-a70d-69226ea47648.png">

<img width="945" alt="2" src="https://user-images.githubusercontent.com/8654229/148529315-a30a35a1-5a16-4663-a019-752c8566cb80.png">

After:
<img width="732" alt="3" src="https://user-images.githubusercontent.com/8654229/148529334-9c42f3d4-96fc-428c-b005-21f67f9bb5e2.png">

